### PR TITLE
Update .gitignore to add support for .DS_Store files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -230,6 +230,7 @@ tags.tmp
 *.xmi
 *.sync
 *.jekyll-metadata
+.DS_Store
 
 # Results director and data files #
 ######################


### PR DESCRIPTION
A simple pull request that adds `.DS_Store` file handling to the `.gitignore` file.